### PR TITLE
Hide border around accordion arrow in Chrome

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -29,7 +29,7 @@
       outline: none;
 
       .#{$prefix}--accordion__arrow {
-        @include focus-outline('border');
+        outline:none; // chrome fix
         overflow: visible; // safari fix
         outline-offset: -0.5px; // safari fix
       }


### PR DESCRIPTION
Chrome shows a border around the Accordion's arrow, on expand/collapse click (while FireFox doesn't).  

The previous SCSS included an outline that shows outline: 1px solid #3d70b2. This cause a rectangle to turn when expanding or collapsing accordion panes.  

Not tested. Edited final carbon-components.css and the fix works there.

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- Removed focus rectangle around Accordion arrow in Chrome.

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
